### PR TITLE
Quick Start Guide: Removed typos, improved grammar, removed unused references

### DIFF
--- a/source/quick_start/animating_shapes.rst
+++ b/source/quick_start/animating_shapes.rst
@@ -47,11 +47,9 @@ separately.
    :alt: FlowerTutorial_2_Canvas.png
 
 
-.. note::
-   Shape `Origin Parameter <Origin_Parameter>`__, transformation and
-   link
+.. note:: Origin parameter
    
-   Be certain that the shape's origin is set to ``0,0`` ... this will
+   Be certain that the shape's 'Origin' parameter is set to ``0,0``. This will
    save you from headhache in further steps.
 
 We're done with the basic settings.

--- a/source/quick_start/animation_basics.rst
+++ b/source/quick_start/animation_basics.rst
@@ -39,7 +39,7 @@ to the ``Time`` tab and make sure to edit ``End Time``. Change “5s” to
 .. note:: Good to know: Synfig and time representation
    Synfig Studio can display the time in various formats (Timestamp). 
    You can configure the Timestamp in Preferences. If the endtime is not
-   displayed in seconds then go to <tt>Edit|Preferences|Misc</tt> and 
+   displayed in seconds then go to ``Edit|Preferences|System`` and 
    change the Timestamp into: (HHh MMm SSs) FFf. 
    More about the Timestamp and its settings can be found
    here ([Preferences_Dialog#Time_Stamp]).

--- a/source/quick_start/bones_cutout.rst
+++ b/source/quick_start/bones_cutout.rst
@@ -247,6 +247,9 @@ The crosshair must stay with our 2 sticks, for the duration of the
 limb's creation.
 
 
+Now you are ready for the **last tutorial** in this section. Hang on!
+
+
 Project File
 ------------
 

--- a/source/quick_start/bones_cutout.rst
+++ b/source/quick_start/bones_cutout.rst
@@ -254,15 +254,6 @@ The zip file containing the parts of this tutorial can be found here:
 :download:`Crosshair-leg.zip <bones_cutout_dat/Crosshair-leg.zip>`
 
 
-Next Steps
-----------
-
-This is the end of the introductory tutorials. From here you can take a
-look at the `Interface <Doc:Interface>`__ page, or continue reading or
-doing the rest of . The gives you a list of the available articles to
-read for a more complete understanding of Synfig.
-
-
 .. |bone.gif| image:: bones_cutout_dat/Bone.gif
 .. |PICTURE 1: Three parts of the arm| image:: bones_cutout_dat/Bonestut01.png
 .. |PICTURE 2: The layers| image:: bones_cutout_dat/Bonestut09.png

--- a/source/quick_start/bones_cutout.rst
+++ b/source/quick_start/bones_cutout.rst
@@ -241,11 +241,11 @@ To transform 2 sticks into 1 leg
 
    Animated Leg.
 
-Important
----------
 
-**The crosshair must stay with our 2 sticks, for the duration of the
-limb's creation.**
+.. admonition:: Important
+The crosshair must stay with our 2 sticks, for the duration of the
+limb's creation.
+
 
 Project File
 ------------

--- a/source/quick_start/creating_shapes.rst
+++ b/source/quick_start/creating_shapes.rst
@@ -231,9 +231,6 @@ their look and shape. For example, if you want a deformed star, then you
 can use the Star Tool to create it as outline and region Splines and
 then use the Transform Tool to deform it.
 
-Now you are ready for the **last tutorial** in
-this section. Hang on!
-
 .. |Reset Colors button in the Toolbox| image:: creating_shapes_dat/Toolbox_Reset_Colors_Button_1_0.png
 
 

--- a/source/quick_start/creating_shapes.rst
+++ b/source/quick_start/creating_shapes.rst
@@ -14,6 +14,9 @@ great but they are pretty much geometrically inflexible. What about
 creating more complex shapes? To do this, we use the `Spline
 Tool <Spline_Tool>`__.
 
+A video on this subject is available
+`here <https://youtu.be/FBnBE9t3Jd8>`__.
+
 Spline Tool
 -----------
 
@@ -223,19 +226,13 @@ tools to create Splines too. Just check the ``Create Outline`` and
 ``Create Region`` options in the Tool Options Panel when using those
 tools.
 
-Creating geometric primitive as Spline gives you a better control over
-it's shape and look. For example, if you want a deformed star, then you
+Creating geometric primitives as Splines gives you better control over
+their look and shape. For example, if you want a deformed star, then you
 can use the Star Tool to create it as outline and region Splines and
 then use the Transform Tool to deform it.
 
-Now you are ready for the `last tutorial <Doc:Flower_Animation>`__ in
+Now you are ready for the **last tutorial** in
 this section. Hang on!
-
-Links
------
-
-A video on this subject is available
-`here <https://youtu.be/FBnBE9t3Jd8>`__
 
 .. |Reset Colors button in the Toolbox| image:: creating_shapes_dat/Toolbox_Reset_Colors_Button_1_0.png
 

--- a/source/quick_start/masking.rst
+++ b/source/quick_start/masking.rst
@@ -106,6 +106,7 @@ Revealing mask method 3.
 Using one 'mask' and one 'full mask'. To be describe (using the linked
 project)
 
+
 Tutorial files
 --------------
 
@@ -116,7 +117,10 @@ Download :download:`tutorial files <masking_dat/Basic_masking_tutorial_files.zip
 .. |Basic_Masking-tutorial_06_0.63.06.png| image:: masking_dat/Basic_Masking-tutorial_06_0.63.06.png
 
 
+Next Steps
+----------
 
-
-
-
+This is the end of the introductory tutorials. From here you can take a
+look at the `Interface <Doc:Interface>`__ page, or continue reading or
+doing the rest of . The gives you a list of the available articles to
+read for a more complete understanding of Synfig.


### PR DESCRIPTION
The cross-references are still a mess by the way. They should be either removed or updated.